### PR TITLE
Flip to settings submodule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 
 
 # TODO:Add settings.py back in later with .env tokens
-personal/settings.py
+personal/settings/base.py
 
 # Django #
 *.log
@@ -141,3 +141,6 @@ GitHub.sublime-settings
 !.vscode/launch.json
 !.vscode/extensions.json
 .history
+
+# PyCharm
+.idea/

--- a/manage.py
+++ b/manage.py
@@ -6,7 +6,7 @@ import sys
 
 def main():
     """Run administrative tasks."""
-    os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'personal.settings')
+    os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'personal.settings.dev')
     try:
         from django.core.management import execute_from_command_line
     except ImportError as exc:

--- a/personal/settings/base.py
+++ b/personal/settings/base.py
@@ -11,9 +11,11 @@ https://docs.djangoproject.com/en/4.1/ref/settings/
 """
 import os
 from pathlib import Path
-from dotenv import load_dotenv, dotenv_values
 
-load_dotenv()
+
+if os.name != 'nt':
+    from dotenv import load_dotenv
+    load_dotenv()
 
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
@@ -28,7 +30,7 @@ SECRET_KEY = os.getenv("SECRET_KEY")
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = ['timeenjoyed.dev', 'www.timeenjoyed.dev', '127.0.0.1', '164.90.147.83', 'localhost']
+ALLOWED_HOSTS = ['127.0.0.1', 'localhost']
 
 # Application definition
 
@@ -84,7 +86,7 @@ TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
         # These templates override pre-defined templates:
-        'DIRS': [os.path.join(BASE_DIR, 'templates')],
+        'DIRS': [os.path.join(BASE_DIR, '../templates')],
         'APP_DIRS': True,
         'OPTIONS': {
             'context_processors': [
@@ -102,44 +104,22 @@ WSGI_APPLICATION = 'personal.wsgi.application'
 
 # Database
 # https://docs.djangoproject.com/en/4.1/ref/settings/#databases
-if not DEBUG:
 
-    DATABASES = {
-        'default': {
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.postgresql',
 
-            'ENGINE': 'django.db.backends.postgresql',
+        'NAME': os.getenv('DATABASE_NAME', 'postgres'),
 
-            'NAME': os.getenv('DATABASE_NAME'),
+        'USER': os.getenv('DATABASE_USER', 'postgres'),
 
-            'USER': os.getenv('DATABASE_USER'),
+        'PASSWORD': os.getenv('DATABASE_PASS', 'postgres'),
 
-            'PASSWORD': os.getenv('DATABASE_PASS'),
+        'HOST': os.getenv('DATABASE_HOST', '127.0.0.1'),
 
-            'HOST': '127.0.0.1',
-
-            'PORT': '',
-
-            }
+        'PORT': os.getenv('DATABASE_PORT', '5432'),
     }
-
-else:
-
-    DATABASES = {
-        'default': {
-
-            'ENGINE': 'django.db.backends.postgresql',
-
-            'NAME': 'timeenjoyeddiscordbot',
-
-            'USER': 'timeenjoyed2',
-
-            'PASSWORD': 'budgie',
-
-            'HOST': '192.168.0.14',
-
-            'PORT': '5432',
-                }
-        }
+}
 
 # Password validation
 # https://docs.djangoproject.com/en/4.1/ref/settings/#auth-password-validators
@@ -176,7 +156,7 @@ USE_TZ = True
 STATIC_URL = '/static/'
 
 STATICFILES_DIRS = [
-    os.path.join(BASE_DIR, "static"),
+    os.path.join(BASE_DIR, "../static"),
 ]
 
 
@@ -188,5 +168,3 @@ DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 # Override's django's default logout
 # LOGIN_REDIRECT_URL = "index"
 # LOGOUT_REDIRECT_URL = "/"
-
-

--- a/personal/settings/dev.py
+++ b/personal/settings/dev.py
@@ -1,0 +1,5 @@
+from .base import *
+
+
+ALLOWED_HOSTS = ['*']
+DEBUG = True

--- a/personal/settings/prod.py
+++ b/personal/settings/prod.py
@@ -1,0 +1,27 @@
+from .base import *
+
+
+DEBUG = False
+
+# Append hosts, not redefine
+ALLOWED_HOSTS += ['timeenjoyed.dev', 'www.timeenjoyed.dev', '164.90.147.83']
+
+# I am assuming this is your prod DB? This should be brought in via envvar
+# base.py covers this already, but transferring to here to not break things.
+# Take note, this is redefining/overriding DATABASES
+DATABASES = {
+    'default': {
+
+        'ENGINE': 'django.db.backends.postgresql',
+
+        'NAME': 'timeenjoyeddiscordbot',
+
+        'USER': 'timeenjoyed2',
+
+        'PASSWORD': 'budgie',
+
+        'HOST': '192.168.0.14',
+
+        'PORT': '5432',
+    }
+}

--- a/personal/settings/test.py
+++ b/personal/settings/test.py
@@ -1,0 +1,5 @@
+from .base import *
+
+
+DEBUG = False
+TESTING = True


### PR DESCRIPTION
This PR moves `settings.py` into `settings/base.py` and makes `settings` a submodule.

This allows you to setup settings for multiple environments (dev, testing, staging, prod), by setting the environment variable `DJANGO_SETTINGS_MODULE`. By default, this is set to `personal.settings.dev`. 

For example, if you were to deploy this to production, you would set it to `personal.settings.prod`

Windows
```
set DJANGO_SETTINGS_MODULE=personal.settings.prod
```

Linux
```sh
export DJANGO_SETTINGS_MODULE=personal.settings.prod
```


This will be particularly useful when you are in local development and may want to disable authentication or in testing and want to flip certain settings around to support mocking things.

## Things to consider
* This works by the non `base.py` settings file, by importing `*` from `.base`, giving you a module structure to work from in your settings
* When you are defining things outside of `base.py`, be aware if you are redefining or modifying the setting. 