### PR TITLE
added pre-commit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 
 # static (to avoid merge conflicts)
 static
+staticfiles
 
 # Django #
 *.log

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,36 @@
+---
+repos:
+  - hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-added-large-files
+    repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.4.0
+
+  - hooks:
+      - id: black
+    repo: https://github.com/ambv/black
+    rev: 23.1.0
+
+  - hooks:
+      - id: prettier
+        types_or: [css, javascript, markdown, scss, yaml, gitignore, toml]
+    repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v3.0.0-alpha.4
+
+  # - hooks:
+  #     - additional_dependencies:
+  #         - flake8-bugbear
+  #         - flake8-comprehensions
+  #         - flake8-mutable
+  #         - flake8-print
+  #         - flake8-simplify
+  #       id: flake8
+  #   repo: https://github.com/pycqa/flake8
+  #   rev: 6.0.0
+  #
+  # - hooks:
+  #     - id: djlint-django
+  #   repo: https://github.com/Riverside-Healthcare/djLint
+  #   rev: v1.19.15

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,8 @@
+[project]
+name = "timeenjoyed-abode"
+version = "0.0.1"
+
+[tool.black]
+line-length = 79
+include = '\.pyi?%'
+exclude = "*/migrations/*"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,8 @@
+[flake8]
+max-line-length = 79
+max-complexity = 12
+ignore = E501, W503, E203
+exclude =
+  .git,
+  .venv
+  env


### PR DESCRIPTION
Related to #5.

Adding pre-commit and code formatting and code linting.

This is how to install pre-commit: https://pre-commit.com/#install

(You shouldn't install this in the virtual environment, this should be installed onto the system python).

Then run `pre-commit install`, and this will install pre-commit as a hook.

When you run your next commit, it will run!

(I turned off flake8 and dj-lint because they are screaming errors lol - errors can be fixed but overwhelming at first!!)

Examples:
![Screenshot 2023-02-27 at 8 12 40 PM](https://user-images.githubusercontent.com/51132467/221497859-d1c3e27b-3b41-4e7d-969d-26a94d948322.png)

If you get annoyed by pre-commit blocking your commit you can always use the `-n` tag to commit without pre-commit running.

`git commit -nm 'pls skip pre-commit lolz'`.

---

Also, I added `/staticfiles` to `.gitignore`. You really don't need staticfiles in source control since this is derived from the installed packages and it is built using the `collectstatic` command, which can be a person can run if they have this code (without the `staticfiles`). Removing `/staticfiles` will make the repo look nicer but this is up to you and you can always execute on this later.

Hope this helps, let me know if you have any questions.

